### PR TITLE
modelsディレクトリを作成してTask、Column、Board、Priorityの型定義とZodスキーマを分離

### DIFF
--- a/components/board/BoardClient.tsx
+++ b/components/board/BoardClient.tsx
@@ -16,31 +16,9 @@ import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useOptimistic, useState, useTransition } from "react";
 import { StaticColumn } from "./StaticColumn";
-
-type Task = {
-  id: string;
-  title: string;
-  description: string | null;
-  priority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
-  dueDate: Date | null;
-  isCompleted: boolean;
-  position: number;
-};
-
-type Column = {
-  id: string;
-  title: string;
-  color: string;
-  position: number;
-  tasks: Task[];
-};
-
-type Board = {
-  id: string;
-  title: string;
-  description: string | null;
-  columns: Column[];
-};
+import { type Task } from "@/models/task";
+import { type Column } from "@/models/column";
+import { type Board } from "@/models/board";
 
 type BoardClientProps = {
   board: Board;

--- a/models/board.ts
+++ b/models/board.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { columnSchema } from "./column";
+
+export const boardSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  columns: z.array(columnSchema),
+});
+
+export type Board = z.infer<typeof boardSchema>;

--- a/models/column.ts
+++ b/models/column.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { taskSchema } from "./task";
+
+export const columnSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  color: z.string(),
+  position: z.number(),
+  tasks: z.array(taskSchema),
+});
+
+export type Column = z.infer<typeof columnSchema>;

--- a/models/priority.ts
+++ b/models/priority.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const prioritySchema = z.enum(["LOW", "MEDIUM", "HIGH", "URGENT"]);
+
+export type Priority = z.infer<typeof prioritySchema>;

--- a/models/task.ts
+++ b/models/task.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { prioritySchema } from "./priority";
+
+export const taskSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  priority: prioritySchema,
+  dueDate: z.date().nullable(),
+  isCompleted: z.boolean(),
+  position: z.number(),
+});
+
+export type Task = z.infer<typeof taskSchema>;


### PR DESCRIPTION
## Summary
- modelsディレクトリを作成し、Task、Column、Board、Priorityの型定義とZodスキーマを分離
- BoardClient.tsxからインライン型定義を削除し、modelsからimportするよう変更
- 型の再利用性とメンテナンス性を向上

## Test plan
- [ ] アプリケーションが正常に起動することを確認
- [ ] ボード画面でタスクのドラッグ&ドロップが正常に動作することを確認
- [ ] 型エラーが発生していないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)